### PR TITLE
Fix: Page Protection not being adjusted in empty sections

### DIFF
--- a/src/Lunar/LibraryMapper.cs
+++ b/src/Lunar/LibraryMapper.cs
@@ -402,16 +402,15 @@ public class LibraryMapper
 
         foreach (var sectionHeader in sectionHeaders)
         {
-            if (sectionHeader.SizeOfRawData == 0)
-            {
-                continue;
-            }
-
-            // Map the raw section
-
             var sectionAddress = DllBaseAddress + sectionHeader.VirtualAddress;
+
+            // Map the raw section if not empty
+
+            if (sectionHeader.SizeOfRawData > 0)
+            {
             var sectionBytes = _dllBytes.Span.Slice(sectionHeader.PointerToRawData, sectionHeader.SizeOfRawData);
             _processContext.Process.WriteSpan(sectionAddress, sectionBytes);
+            }
 
             // Determine the protection to apply to the section
 


### PR DESCRIPTION
Originally the sections that have no raw data (SizeOfRawData == 0) were skipped completely, ommitting their protection flags.

This would cause an access violation during runtime if data were written to that section (most packers, NativeAOT compiled libraries), expecting the protection flags to be properly set by the loader.

P.S. This condition works in other common sources because they do not process section data and protection flags simutaneously e.g. Blackbone.